### PR TITLE
minor ui changes in search by region

### DIFF
--- a/app/assets/stylesheets/busquedas/region/por_region_extra.scss
+++ b/app/assets/stylesheets/busquedas/region/por_region_extra.scss
@@ -74,6 +74,7 @@
 
 .boton-especie-registros {
   outline: none!important;
+  line-height: normal;
 }
 
 #nombre-region-hover {

--- a/app/views/busquedas_regiones/especies.html.erb
+++ b/app/views/busquedas_regiones/especies.html.erb
@@ -45,7 +45,7 @@
 
         <button class="border-0 m-0 p-0 text-right boton-especie-registros" especie_id_focus="<%= taxon.id %>" catalogo_id="<%= taxon.catalogo_id %>" title="Mostrar registros" data-nombre-cientifico="<%= taxon.nombre_cientifico.sanitize.html_safe %>">
           <div class="result-img-container w-100 mt-0 mb-n4 text-break">
-            <%= taxon.foto_principal.present? ? image_tag(taxon.foto_principal, class: 'img-fluid', alt: 'Imagen no encontrada') : "<i class='ev1-ev-icon'></i>".html_safe %>
+            <%= taxon.foto_principal.present? ? image_tag(taxon.foto_principal, class: 'img-fluid', alt: taxon.nombre_cientifico.sanitize.html_safe) : "<i class='ev1-ev-icon'></i>".html_safe %>
           </div>
           <span class="badge badge-light position-relative"><%= number_with_delimiter(t[:nregistros], delimiter: ',') %></span>
         </button>


### PR DESCRIPTION
En la [búsqueda por región](https://enciclovida.mx/explora-por-region?utf8=%E2%9C%93&pagina=2#6/17.665/-77.860)
- agrega alt text en las imágenes de las especies
- quita un espacio en blanco que aparece en el `<button>` al momento de hacer hover

![image](https://github.com/CONABIO/enciclovida/assets/12853324/035ca2de-7626-4ccd-878b-594462ea5469)
